### PR TITLE
Fixed foundry script

### DIFF
--- a/script/Clusters.s.sol
+++ b/script/Clusters.s.sol
@@ -7,7 +7,7 @@ import {PricingHarberger} from "../src/PricingHarberger.sol";
 import {Endpoint} from "../src/Endpoint.sol";
 import {Clusters} from "../src/Clusters.sol";
 
-contract CounterScript is Script {
+contract ClustersScript is Script {
     address constant SIGNER = address(uint160(uint256(keccak256(abi.encodePacked("SIGNER")))));
 
     function setUp() public {}
@@ -15,8 +15,8 @@ contract CounterScript is Script {
     function run() public {
         vm.startBroadcast();
         PricingHarberger pricing = new PricingHarberger();
-        Endpoint endpoint = new Endpoint(address(this), SIGNER);
-        new Clusters(address(pricing), address(endpoint), block.timestamp);
+        Endpoint endpoint = new Endpoint(msg.sender, SIGNER);
+        new Clusters(address(pricing), address(endpoint), block.timestamp + 7 days);
         vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
The foundry script had a bug where it wouldn't deploy Clusters to Anvil. Because script TXs are individual and not bundled, each TX happens 1ms after the previous. Clusters.sol has a constructor parameter marketOpenTimestamp_ that will trigger a revert if a timestamp in the past is set. Using block.timestamp technically would work if the TX's were bundled, but because they're not, technically the timestamp is block.timestamp + 2 when Clusters.sol is deployed, so block.timestamp appears to be in the past. Adjusting this to the default of +7 days fixes this.