### PR TITLE
refactored transferName() to use addresses instead of clusterIds

### DIFF
--- a/src/ClustersHub.sol
+++ b/src/ClustersHub.sol
@@ -180,7 +180,6 @@ contract ClustersHub is NameManagerHub {
     }
 
     function _hookCheck(uint256 clusterId) internal view override {
-        if (clusterId == 0) return;
         if (_verifiedAddresses[clusterId].length() == 0) revert Invalid();
     }
 

--- a/src/interfaces/IClustersHub.sol
+++ b/src/interfaces/IClustersHub.sol
@@ -98,8 +98,8 @@ interface IClustersHub {
         external
         payable
         returns (bytes memory);
-    function transferName(string memory name, uint256 toClusterId) external payable returns (bytes memory);
-    function transferName(bytes32 msgSender, string memory name, uint256 toClusterId)
+    function transferName(string memory name, bytes32 recipient) external payable returns (bytes memory);
+    function transferName(bytes32 msgSender, string memory name, bytes32 recipient)
         external
         payable
         returns (bytes memory);

--- a/test/GasBenchmark.t.sol
+++ b/test/GasBenchmark.t.sol
@@ -59,9 +59,9 @@ contract GasBenchmarkTest is Base_Test {
 
         vm.startPrank(users.alicePrimary);
         clusters.buyName{value: minPrice}(minPrice, "burned");
-        clusters.transferName("burned", 0);
+        clusters.transferName("burned", bytes32(""));
         clusters.acceptBid(constants.TEST_NAME());
-        clusters.transferName("zodomo", 2);
+        clusters.transferName("zodomo", _addressToBytes32(users.bidder));
         vm.stopPrank();
     }
 }

--- a/test/unit/local/concrete/Clusters_refundBid.t.sol
+++ b/test/unit/local/concrete/Clusters_refundBid.t.sol
@@ -21,7 +21,7 @@ contract Clusters_refundBid_Unit_Concrete_Test is PricingHarberger_Unit_Shared_T
 
     function testRefundBidTransferBurn() public {
         vm.startPrank(users.alicePrimary);
-        clusters.transferName(constants.TEST_NAME(), 0);
+        clusters.transferName(constants.TEST_NAME(), bytes32(""));
         vm.stopPrank();
         assertEq(minPrice * 2, clusters.bidRefunds(_addressToBytes32(address(fickleReceiver))), "bidRefunds incorrect");
         assertBalances(minPrice * 6, minPrice, minPrice, minPrice * 4);
@@ -55,7 +55,7 @@ contract Clusters_refundBid_Unit_Concrete_Test is PricingHarberger_Unit_Shared_T
     function testRefundBid_Reverts() public {
         fickleReceiver.toggle();
         vm.startPrank(users.alicePrimary);
-        clusters.transferName(constants.TEST_NAME(), 0);
+        clusters.transferName(constants.TEST_NAME(), bytes32(""));
         vm.expectRevert(IClustersHub.NoBid.selector);
         clusters.refundBid();
         vm.expectRevert(IClustersHub.Unauthorized.selector);

--- a/test/unit/local/concrete/Clusters_transferName.t.sol
+++ b/test/unit/local/concrete/Clusters_transferName.t.sol
@@ -20,7 +20,7 @@ contract Clusters_transferName_Unit_Concrete_Test is PricingHarberger_Unit_Share
 
     function testTransferName() public {
         vm.startPrank(users.alicePrimary);
-        clusters.transferName("FOOBAR", 2);
+        clusters.transferName("FOOBAR", _addressToBytes32(users.bobPrimary));
         vm.stopPrank();
 
         bytes32[] memory names = new bytes32[](1);
@@ -34,12 +34,12 @@ contract Clusters_transferName_Unit_Concrete_Test is PricingHarberger_Unit_Share
 
     function testTransferNameZeroCluster() public {
         vm.startPrank(users.alicePrimary);
-        clusters.transferName("FOOBAR", 0);
+        clusters.transferName("FOOBAR", bytes32(""));
         clusters.bidName{value: minPrice}(minPrice, "zodomo");
         vm.stopPrank();
 
         vm.prank(users.bobPrimary);
-        clusters.transferName("zodomo", 0);
+        clusters.transferName("zodomo", bytes32(""));
 
         bytes32[] memory empty;
         assertClusterNames(0, 0, empty);
@@ -50,8 +50,8 @@ contract Clusters_transferName_Unit_Concrete_Test is PricingHarberger_Unit_Share
 
     function testTransferNameAll() public {
         vm.startPrank(users.alicePrimary);
-        clusters.transferName("FOOBAR", 2);
-        clusters.transferName(constants.TEST_NAME(), 2);
+        clusters.transferName("FOOBAR", _addressToBytes32(users.bobPrimary));
+        clusters.transferName(constants.TEST_NAME(), _addressToBytes32(users.bobPrimary));
         vm.stopPrank();
 
         bytes32[] memory empty;
@@ -67,22 +67,24 @@ contract Clusters_transferName_Unit_Concrete_Test is PricingHarberger_Unit_Share
     function testTransferName_Reverts() public {
         vm.startPrank(users.alicePrimary);
         vm.expectRevert(IClustersHub.EmptyName.selector);
-        clusters.transferName("", 2);
+        clusters.transferName("", _addressToBytes32(users.bobPrimary));
         vm.expectRevert(IClustersHub.LongName.selector);
-        clusters.transferName("Privacy is necessary for an open society in the electronic age.", 2);
+        clusters.transferName(
+            "Privacy is necessary for an open society in the electronic age.", _addressToBytes32(users.bobPrimary)
+        );
 
         vm.expectRevert(IClustersHub.Unauthorized.selector);
-        clusters.transferName("zodomo", 1);
+        clusters.transferName("zodomo", _addressToBytes32(users.alicePrimary));
         vm.expectRevert(IClustersHub.Unauthorized.selector);
-        clusters.transferName(_addressToBytes32(users.bobPrimary), "FOOBAR", 0);
+        clusters.transferName(_addressToBytes32(users.bobPrimary), "FOOBAR", bytes32(""));
 
         vm.expectRevert(IClustersHub.Invalid.selector);
-        clusters.transferName("FOOBAR", 3);
+        clusters.transferName("FOOBAR", _addressToBytes32(users.aliceSecondary));
         vm.stopPrank();
 
         vm.prank(users.hacker);
         vm.expectRevert(IClustersHub.NoCluster.selector);
-        clusters.transferName(_addressToBytes32(users.hacker), "FOOBAR", 0);
+        clusters.transferName(_addressToBytes32(users.hacker), "FOOBAR", bytes32(""));
         vm.stopPrank();
     }
 }

--- a/test/unit/remote/concrete/inbound/Endpoint_transferName.t.sol
+++ b/test/unit/remote/concrete/inbound/Endpoint_transferName.t.sol
@@ -23,7 +23,10 @@ contract Inbound_Endpoint_transferName_Unit_Concrete_Test is Inbound_Harberger_S
     function testTransferName() public {
         vm.startPrank(users.alicePrimary);
         bytes memory data = abi.encodeWithSignature(
-            "transferName(bytes32,string,uint256)", _addressToBytes32(users.alicePrimary), "FOOBAR", 2
+            "transferName(bytes32,string,bytes32)",
+            _addressToBytes32(users.alicePrimary),
+            "FOOBAR",
+            _addressToBytes32(users.bobPrimary)
         );
         bytes memory options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(250_000 gwei, 0);
         (uint256 nativeFee,) = remoteEndpoint.quote(1, data, options, false);


### PR DESCRIPTION
I refactored transferName() to use bytes32 addresses rather than uint256 clusterIds. I felt that using addresses is more intuitive, rather than locating a clusterId first.